### PR TITLE
Guard pointer capture for zone drag compatibility

### DIFF
--- a/app.js
+++ b/app.js
@@ -263,7 +263,12 @@ function initZoneBar() {
   $('#zone_iso').oninput = () => applyZoneExposure(num('#zone_ev'));
 
   let dragging = false;
-  const onPointerDown = (e) => { dragging = true; zoneThumb.setPointerCapture?.(e.pointerId); };
+  const onPointerDown = (e) => {
+    dragging = true;
+    if (zoneThumb.setPointerCapture) {
+      zoneThumb.setPointerCapture(e.pointerId);
+    }
+  };
   const onPointerMove = (e) => {
     if (!dragging) return;
     const rect = zoneTrack.getBoundingClientRect();


### PR DESCRIPTION
## Summary
- guard the zone drag pointer capture call to avoid errors on browsers without the API
- rebuild the web assets and copy them into the Android project

## Testing
- npm run build
- npx cap copy android

------
https://chatgpt.com/codex/tasks/task_b_68d6d79b99348333855974b29d00e882