### PR TITLE
Build expense report builder with policy automation

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,176 +4,199 @@
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover"/>
   <link rel="manifest" href="manifest.webmanifest">
-  <meta name="theme-color" content="#111">
-  <title>Exposure Calculator</title>
+  <meta name="theme-color" content="#0f172a">
+  <title>FSI Expense Report Builder</title>
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-  <header><h1>📸 Exposure Calculator (Offline)</h1></header>
+  <header>
+    <div class="logo">FSI</div>
+    <div>
+      <h1>Expense Report Builder</h1>
+      <p class="tagline">Collect expenses, validate company policy, and prep the month-end packet &mdash; even offline.</p>
+    </div>
+  </header>
 
   <main>
-    <!-- Global Adjustments -->
     <section class="card">
-      <h2>Global Adjustments</h2>
+      <h2>Report Header</h2>
       <div class="grid">
-        <label>Filter Factor (×)
-          <input id="ff_factor" type="number" step="0.1" min="1" value="1">
+        <label>Name
+          <input id="field_name" type="text" placeholder="Employee name">
         </label>
-        <label>ND / Filter Stops (stops)
-          <input id="ff_stops" type="number" step="0.1" value="0">
+        <label>Department
+          <input id="field_department" type="text" placeholder="Department or team">
         </label>
-        <label>Reciprocity Model
-          <select id="rec_model">
-            <option value="none">None</option>
-            <option value="generic">Generic</option>
-            <option value="hp5">Ilford HP5+</option>
-            <option value="trix">Kodak Tri‑X 400</option>
-            <option value="acros2">Fujifilm Acros II</option>
-            <option value="custom">Custom (set points)</option>
-          </select>
+        <label>Expense Type / Focus
+          <input id="field_focus" type="text" placeholder="e.g., Mileage & supplies">
+        </label>
+        <label>Purpose of Trip / Project
+          <input id="field_purpose" type="text" placeholder="Client visit, project, etc.">
+        </label>
+        <label>JE Number
+          <input id="field_je" type="text" placeholder="Optional journal entry #">
+        </label>
+        <label>Date Range
+          <input id="field_dates" type="text" placeholder="e.g., Dec 4&ndash;7 2023">
+        </label>
+        <label>Trip Length (days)
+          <input id="field_trip_length" type="number" min="0" step="1" placeholder="0">
         </label>
       </div>
-      <div class="grid">
-        <label>Custom @ 1s (stops) <input id="rec_c1" type="number" step="0.1" value="1.0"></label>
-        <label>Custom @ 10s (stops) <input id="rec_c10" type="number" step="0.1" value="2.0"></label>
-        <label>Custom @ 100s (stops) <input id="rec_c100" type="number" step="0.1" value="3.5"></label>
-      </div>
-      <p class="hint">Filter factor adds exposure (stops = log₂(factor)). Reciprocity adds extra stops for long exposures. Both reduce effective EV.</p>
     </section>
 
-    <!-- Manual (any two → solve the others) -->
     <section class="card">
-      <h2>Manual</h2>
-      <div class="grid">
-        <label>ISO <input id="iso" type="number" min="1" value="100"></label>
-        <label>Aperture (f) <input id="ap" type="number" step="0.1" value="8"></label>
-        <label>Shutter (s) <input id="tv" type="number" step="0.0001" value="0.01"></label>
-        <label>EV100 <input id="ev" type="number" step="0.1"></label>
-      </div>
-      <p class="hint">Enter any two fields; click “Solve”.</p>
-      <button id="solveManual">Solve</button>
-      <pre id="manualOut"></pre>
+      <h2>Policy Quick Reference</h2>
+      <details open>
+        <summary>Travel &amp; transportation</summary>
+        <ul>
+          <li>Domestic airfare: book lowest available coach fare. First-class upgrades are personal expense.</li>
+          <li>International airfare: business class allowed only when the published flight time is eight hours or more.</li>
+          <li>Use long-term parking when away for 36+ hours. Mileage reimbursed at the current IRS rate above normal commute.</li>
+          <li>Hotel gym fees reimbursable up to $15 per day.</li>
+          <li>Laundry only reimbursed on trips longer than seven full days.</li>
+        </ul>
+      </details>
+      <details>
+        <summary>Meals &amp; entertainment</summary>
+        <ul>
+          <li>Receipts are required for all meals. Without a receipt, reimbursement caps apply: $10 breakfast, $15 lunch, $25 dinner.</li>
+          <li>Only business-related entertainment where work was discussed is reimbursable.</li>
+        </ul>
+      </details>
+      <details>
+        <summary>Non-reimbursable highlights</summary>
+        <ul>
+          <li>First-class airfare, personal entertainment, personal grooming, and traffic fines.</li>
+          <li>Airline club dues, personal sundries, and theft of personal property (unless covered by rental insurance).</li>
+        </ul>
+      </details>
     </section>
 
-    <!-- Sunny 16 -->
-    <section class="card">
-      <h2>Sunny 16 Guide</h2>
-      <label>ISO <input id="s16_iso" type="number" min="1" value="100"></label>
-      <label>Light
-        <select id="s16_cond">
-          <option>Bright Sun</option>
-          <option>Hazy Sun</option>
-          <option>Open Shade</option>
-          <option>Heavy Overcast</option>
-          <option>Indoors (bright)</option>
-        </select>
-      </label>
-      <button id="s16_calc">Suggest</button>
-      <pre id="s16Out"></pre>
+    <section class="card" id="expensesCard">
+      <div class="card-header">
+        <h2>Expenses</h2>
+        <button id="addExpense" type="button">+ Add expense</button>
+      </div>
+      <div class="table-scroll">
+        <table id="expensesTable">
+          <thead>
+            <tr>
+              <th>Date</th>
+              <th>Type</th>
+              <th>Account</th>
+              <th>Description / Details</th>
+              <th>Payment</th>
+              <th>Amount</th>
+              <th>Reimbursable</th>
+              <th>Policy notes</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody id="expensesBody"></tbody>
+        </table>
+      </div>
     </section>
 
-    <!-- ISO conversion -->
-    <section class="card">
-      <h2>ISO Conversion</h2>
-      <div class="grid">
-        <label>Metered ISO <input id="conv_iso_a" type="number" value="100"></label>
-        <label>f/ <input id="conv_ap" type="number" step="0.1" value="8"></label>
-        <label>t (s) <input id="conv_tv" type="number" step="0.0001" value="0.01"></label>
-        <label>Target ISO <input id="conv_iso_b" type="number" value="400"></label>
-      </div>
-      <button id="conv_calc">Convert</button>
-      <pre id="convOut"></pre>
-    </section>
-
-    <!-- Zone System slide-rule -->
-    <section class="card">
-      <h2>Zone System</h2>
-      <div class="grid">
-        <label>ISO <input id="zone_iso" type="number" value="100"></label>
-        <label>Lock
-          <select id="zone_lock">
-            <option value="ap">Aperture Priority (lock f/)</option>
-            <option value="tv">Shutter Priority (lock t)</option>
-          </select>
-        </label>
-        <label>f/ <input id="zone_ap" type="number" step="0.1" value="8"></label>
-        <label>t (s) <input id="zone_tv" type="number" step="0.0001" value="0.01"></label>
-      </div>
-      <div class="grid">
-        <label>Zone V EV (ISO 100)
-          <input id="zone_ev_number" type="number" step="0.1" value="12">
-        </label>
-        <label>Slide V (middle gray)
-          <input id="zone_ev" type="range" min="3" max="18" step="0.1" value="12">
-        </label>
-      </div>
-      <div class="zonebar" id="zonebar">
-        <div class="zonebar-track" id="zonebarTrack">
-          <div class="zone-seg">0</div><div class="zone-seg">I</div><div class="zone-seg">II</div>
-          <div class="zone-seg">III</div><div class="zone-seg">IV</div><div class="zone-seg">V</div>
-          <div class="zone-seg">VI</div><div class="zone-seg">VII</div><div class="zone-seg">VIII</div>
-          <div class="zone-seg">IX</div><div class="zone-seg">X</div>
-          <div class="zone-thumb" id="zoneThumb" title="Drag to shift EV (Zone V)"></div>
+    <section class="card" id="totalsCard">
+      <h2>Totals</h2>
+      <dl class="totals">
+        <div>
+          <dt>Total submitted</dt>
+          <dd id="totalSubmitted">$0.00</dd>
         </div>
-        <div class="zonebar-evs" id="zonebarEVs"></div>
-      </div>
-      <pre id="zoneOut"></pre>
+        <div>
+          <dt>Due to employee</dt>
+          <dd id="totalDueEmployee">$0.00</dd>
+        </div>
+        <div>
+          <dt>Company card</dt>
+          <dd id="totalCompanyCard">$0.00</dd>
+        </div>
+      </dl>
     </section>
 
-    <!-- Converter (left → right) -->
     <section class="card">
-      <h2>Converter</h2>
-      <div class="grid two">
-        <fieldset>
-          <legend>Left (Baseline)</legend>
-          <label>ISO <input id="left_iso" type="number" value="100"></label>
-          <label>f/ <input id="left_ap" type="number" step="0.1" value="8"></label>
-          <label>t (s) <input id="left_tv" type="number" step="0.0001" value="0.01"></label>
-        </fieldset>
-        <fieldset>
-          <legend>Right (Adjusted)</legend>
-          <label>ISO <input id="right_iso" type="number" value="400"></label>
-          <div>
-            <button id="btn_ap_pri">Aperture Priority</button>
-            <button id="btn_tv_pri">Shutter Priority</button>
-          </div>
-          <label>f/ <input id="right_ap" type="number" step="0.1" value="8"></label>
-          <label>t (s) <input id="right_tv" type="number" step="0.0001" value="0.01"></label>
-        </fieldset>
-      </div>
-      <button id="convert">Convert</button>
-      <pre id="conv2Out"></pre>
-    </section>
-
-    <!-- Live Meter (camera) – dev module (OFF by default) -->
-    <section class="card" id="liveMeterCard" hidden>
-      <h2>Live Meter (Camera)</h2>
-      <div class="grid">
-        <button id="meter_start">Start Meter</button>
-        <button id="meter_calib">Calibrate (Zone V)</button>
-        <button id="meter_stop">Stop</button>
-      </div>
-      <div class="grid">
-        <label>Cal EV100 (at calibration)
-          <input id="meter_ev_cal" type="number" step="0.1" value="10.0">
-        </label>
-        <label>Use Live EV Globally
-          <input id="meter_use_global" type="checkbox">
-        </label>
-      </div>
-      <p class="hint">Point at 18% gray and press Calibrate. EV is relative to that.</p>
-      <div>EV100 Live: <strong id="meter_ev100">—</strong></div>
-      <div>EV@ISO: <strong id="meter_ev_iso">—</strong></div>
-      <video id="meter_video" autoplay playsinline style="display:none;"></video>
-      <canvas id="meter_canvas" width="160" height="120" style="display:none;"></canvas>
+      <h2>Report Preview</h2>
+      <p class="hint">Snapshot updates automatically. Copy and paste into the official form.</p>
+      <textarea id="reportPreview" readonly rows="10"></textarea>
+      <button id="copyPreview" type="button">Copy summary</button>
+      <p class="copy-feedback" id="copyFeedback" role="status" aria-live="polite"></p>
     </section>
   </main>
+
+  <template id="expense-row-template">
+    <tr class="expense-row">
+      <td><input type="date" class="exp-date"></td>
+      <td>
+        <select class="exp-type"></select>
+        <div class="detail" data-detail="meal">
+          <label>Meal type
+            <select class="exp-meal-type">
+              <option value="breakfast">Breakfast ($10 cap w/out receipt)</option>
+              <option value="lunch">Lunch ($15 cap w/out receipt)</option>
+              <option value="dinner">Dinner ($25 cap w/out receipt)</option>
+            </select>
+          </label>
+          <label class="checkbox"><input type="checkbox" class="exp-receipt" checked> Receipt provided</label>
+        </div>
+        <div class="detail" data-detail="mileage">
+          <label>Miles driven <input type="number" min="0" step="0.1" class="exp-miles"></label>
+          <p class="hint">Reimbursed at current IRS rate.</p>
+        </div>
+        <div class="detail" data-detail="travel">
+          <label>Travel category
+            <select class="exp-travel-cat">
+              <option value="air_domestic">Airfare &ndash; Domestic</option>
+              <option value="air_international">Airfare &ndash; International</option>
+              <option value="lodging">Lodging / Hotel</option>
+              <option value="parking">Parking / Tolls</option>
+              <option value="ground">Ground transport (taxi, rideshare, shuttle)</option>
+              <option value="laundry">Laundry / Dry cleaning</option>
+              <option value="gym">Hotel gym</option>
+              <option value="other">Other travel</option>
+            </select>
+          </label>
+          <label data-flight-only>Class of service
+            <select class="exp-travel-class">
+              <option value="coach">Coach</option>
+              <option value="premium">Premium economy</option>
+              <option value="business">Business</option>
+              <option value="first">First</option>
+            </select>
+          </label>
+          <label data-flight-only>Published flight hours
+            <input type="number" min="0" step="0.1" class="exp-flight-hours" placeholder="0">
+          </label>
+        </div>
+      </td>
+      <td class="expense-account">&mdash;</td>
+      <td>
+        <textarea class="exp-description" rows="2" placeholder="Describe the business purpose"></textarea>
+      </td>
+      <td>
+        <select class="exp-payment">
+          <option value="personal">Personal funds</option>
+          <option value="company">Company card</option>
+        </select>
+      </td>
+      <td>
+        <input type="number" min="0" step="0.01" class="exp-amount" placeholder="0.00">
+        <div class="detail" data-detail="mileage"><span class="mileage-rate"></span></div>
+      </td>
+      <td class="expense-reimbursable">$0.00</td>
+      <td>
+        <ul class="policy-messages"></ul>
+      </td>
+      <td>
+        <button type="button" class="remove-expense" title="Remove">&times;</button>
+      </td>
+    </tr>
+  </template>
 
   <script type="module">
     import './storage.js';
     import './app.js';
-    // Optional live meter: uncomment to enable camera-based metering UI.
-    // import './modules/live_meter.js';
   </script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1,111 +1,344 @@
-:root { --bg:#111; --fg:#eee; --card:#1b1b1b; --muted:#aaa; }
-
-/* ADDED: keep everything inside the viewport */
-html, body { margin:0; padding:0; width:100%; overflow-x:hidden; }
-
-* { box-sizing: border-box; font-family: system-ui, sans-serif; }
-body { margin:0; background:var(--bg); color:var(--fg); }
-
-/* UPDATED: make the app clamp to phone width instead of stretching */
-header { padding:16px 20px; border-bottom:1px solid #222; }
-main {
-  padding:16px;
-  display:grid;
-  gap:16px;
-  width:100%;                                /* NEW */
-  max-width: clamp(320px, 96vw, 560px);      /* NEW: pick a max you like */
-  margin:0 auto;
+:root {
+  --bg: #0b1120;
+  --card: #111c34;
+  --fg: #f8fafc;
+  --muted: #94a3b8;
+  --accent: #38bdf8;
+  --warning: #f97316;
 }
 
-.card { background:var(--card); padding:16px; border-radius:10px; }
-
-/* UPDATED: let tiles shrink further on small screens */
-.grid {
-  display:grid;
-  gap:10px;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); /* was 180px */
+* {
+  box-sizing: border-box;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
 }
 
-/* still available when you explicitly want two equal columns */
-.grid.two { grid-template-columns: 1fr 1fr; gap:16px; }
-
-label { display:flex; flex-direction:column; gap:6px; font-size:14px; }
-
-/* ADDED: full-width controls on narrow screens */
-input, select, button { width:100%; min-width:0; padding:10px; border-radius:8px; border:1px solid #333; background:#000; color:#fff; }
-
-button { cursor:pointer; }
-
-/* UPDATED: prevent horizontal scroll from long lines */
-pre { background:#000; padding:10px; border-radius:8px; overflow:auto; white-space:pre-wrap; overflow-wrap:anywhere; }
-
-.hint { color:var(--muted); margin:0 0 8px 0; }
-
-/* ---- Zone bar ---- */
-.zonebar { margin-top:10px; }
-
-/* ADDED: make the bar respect container width */
-.zonebar, .zonebar-track, .zonebar-evs { width:100%; }
-
-.zonebar-track {
-  position: relative;
-  display: grid;
-  grid-template-columns: repeat(11, 1fr);
-  height: 48px;
-  border: 1px solid #333;
-  border-radius: 8px;
-  overflow: hidden;
-  user-select: none;
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--fg);
+  min-height: 100%;
 }
 
-.zone-seg {
+body {
+  display: flex;
+  flex-direction: column;
+}
+
+header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 24px 20px 12px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+header .logo {
+  width: 56px;
+  height: 56px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.8), rgba(14, 116, 144, 0.8));
   display: flex;
   align-items: center;
   justify-content: center;
-  font-weight: 600;
-  border-right: 1px solid #222;
+  font-weight: 700;
+  letter-spacing: 0.12em;
 }
 
-/* Optional: slightly smaller labels on tiny screens */
-@media (max-width: 380px) {
-  .zone-seg { font-size: 0.85rem; }
+header h1 {
+  margin: 0 0 6px;
+  font-size: clamp(1.6rem, 2vw + 1rem, 2.2rem);
 }
 
-.zone-seg:nth-child(1)  { background: #000000; color:#fff; }
-.zone-seg:nth-child(2)  { background: #1b1b1b; color:#fff; }
-.zone-seg:nth-child(3)  { background: #303030; color:#fff; }
-.zone-seg:nth-child(4)  { background: #474747; color:#fff; }
-.zone-seg:nth-child(5)  { background: #5e5e5e; color:#fff; }
-.zone-seg:nth-child(6)  { background: #7a7a7a; color:#000; }
-.zone-seg:nth-child(7)  { background: #9a9a9a; color:#000; }
-.zone-seg:nth-child(8)  { background: #bbbbbb; color:#000; }
-.zone-seg:nth-child(9)  { background: #d9d9d9; color:#000; }
-.zone-seg:nth-child(10) { background: #f0f0f0; color:#000; }
-.zone-seg:nth-child(11) { background: #ffffff; color:#000; }
-
-.zone-thumb {
-  position: absolute;
-  top: -6px;
-  height: 60px;
-  width: 4px;
-  background: #00d2ff;
-  border-radius: 3px;
-  box-shadow: 0 0 0 3px rgba(0,210,255,0.25);
-  cursor: grab;
+header .tagline {
+  margin: 0;
+  color: var(--muted);
+  max-width: 620px;
 }
-.zone-thumb:active { cursor: grabbing; }
 
-.zonebar-evs {
+main {
+  width: min(1120px, 95vw);
+  margin: 0 auto 48px;
+  padding: 24px 0 48px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.card {
+  background: var(--card);
+  border-radius: 16px;
+  padding: 20px;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.35);
+}
+
+.card h2 {
+  margin-top: 0;
+  font-size: 1.2rem;
+}
+
+.grid {
   display: grid;
-  grid-template-columns: repeat(11, 1fr);
-  gap: 0;
-  margin-top: 6px;
-  font-size: 12px;
-  color: #ccc;
-  text-align: center;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
-/* ADDED: media tweak to force single column if it still feels cramped */
-@media (max-width: 420px) {
-  .grid { grid-template-columns: 1fr; }
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 0.9rem;
+}
+
+input,
+select,
+textarea,
+button {
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.85);
+  color: var(--fg);
+  padding: 10px 12px;
+  font-size: 0.95rem;
+}
+
+input::placeholder,
+textarea::placeholder {
+  color: rgba(148, 163, 184, 0.7);
+}
+
+button {
+  cursor: pointer;
+  background: rgba(56, 189, 248, 0.15);
+  border-color: rgba(56, 189, 248, 0.4);
+  transition: background 0.15s ease, transform 0.15s ease;
+}
+
+button:hover {
+  background: rgba(56, 189, 248, 0.25);
+  transform: translateY(-1px);
+}
+
+button:active {
+  transform: translateY(0);
+}
+
+textarea {
+  resize: vertical;
+  min-height: 70px;
+}
+
+.checkbox {
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+}
+
+.checkbox input {
+  width: auto;
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.card-header button {
+  flex-shrink: 0;
+}
+
+.table-scroll {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 820px;
+}
+
+thead th {
+  text-align: left;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+  padding-bottom: 10px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+tbody td {
+  padding: 12px 10px;
+  vertical-align: top;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.expense-row input,
+.expense-row select,
+.expense-row textarea {
+  width: 100%;
+}
+
+.expense-row textarea {
+  min-height: 72px;
+}
+
+.detail {
+  margin-top: 10px;
+  padding: 12px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  display: grid;
+  gap: 12px;
+}
+
+.detail[hidden] {
+  display: none;
+}
+
+.detail label {
+  font-size: 0.85rem;
+}
+
+.detail .hint {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.expense-account {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.expense-reimbursable {
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.policy-messages {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.policy-messages li {
+  font-size: 0.85rem;
+  border-left: 3px solid transparent;
+  padding-left: 8px;
+}
+
+.policy-messages li.warning {
+  border-color: var(--warning);
+  color: var(--warning);
+}
+
+.policy-messages li.info {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.remove-expense {
+  background: transparent;
+  border: 1px solid rgba(248, 113, 113, 0.45);
+  color: #fca5a5;
+  padding: 8px 12px;
+  border-radius: 8px;
+}
+
+.remove-expense:hover {
+  background: rgba(248, 113, 113, 0.1);
+}
+
+.remove-expense:active {
+  transform: scale(0.96);
+}
+
+.totals {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  margin: 0;
+}
+
+.totals div {
+  background: rgba(15, 23, 42, 0.6);
+  padding: 16px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.totals dt {
+  margin: 0 0 4px;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  color: var(--muted);
+  letter-spacing: 0.08em;
+}
+
+.totals dd {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 600;
+}
+
+.hint {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+#reportPreview {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  min-height: 200px;
+}
+
+.copy-feedback {
+  height: 1.2rem;
+  margin-top: 6px;
+  color: var(--muted);
+}
+
+input.readonly {
+  background: rgba(15, 23, 42, 0.5);
+  color: var(--muted);
+}
+
+@media (max-width: 860px) {
+  header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  header .logo {
+    width: 48px;
+    height: 48px;
+  }
+
+  table {
+    min-width: 720px;
+  }
+}
+
+@media (max-width: 600px) {
+  main {
+    width: 100%;
+    padding-inline: 16px;
+  }
+
+  .card {
+    padding: 18px;
+  }
 }


### PR DESCRIPTION
## Summary
- replace the exposure calculator shell with an expense reporting workflow tailored to company policy
- add dynamic expense-row logic for meal caps, mileage reimbursement, travel checks, totals, and clipboard-ready summaries
- refresh the UI styling to support the new table, policy guidance, and totals cards

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68deb10aeb0c833383ce5938a8c4b4e9